### PR TITLE
Fix "No such file or directory" error

### DIFF
--- a/Makefile.android
+++ b/Makefile.android
@@ -117,7 +117,7 @@ build.android/wine-tools/Makefile: wine/configure build.android/aarch64-linux-an
 
 build.android/wine-tools/.built: build.android/wine-tools/Makefile
 	+$(MAKE) -C build.android/wine-tools tools tools/sfnt2fon tools/widl tools/winebuild tools/winegcc tools/wmc tools/wrc
-	@mkdir -p build
+	@mkdir -p build/wine-host
 	ln -sf $(WINE_HOST) build/wine-host
 	ln -sf ../wine-tools/tools build.android/wine-host/
 	@touch build.android/wine-tools/.built


### PR DESCRIPTION
Fix folder error when entering "ln -sf $(WINE_HOST) build/wine-host" command
It's tested