### PR TITLE
Makefile: Fix Makefile.android.

### DIFF
--- a/Makefile.android
+++ b/Makefile.android
@@ -143,6 +143,7 @@ build.android/wine-guest/Makefile: build.android/wine-tools/.built wine/configur
 	cd $(@D) ; ../../wine/configure --host=x86_64-w64-mingw32 --with-wine-tools=../wine-tools --without-freetype --disable-tests
 
 wine-guest: build.android/wine-guest/Makefile
+	+$(MAKE) -C build.android/wine-guest/libs/port
 	+$(MAKE) -C build.android/wine-guest $(patsubst %,dlls/%,$(WINEDLLS))
 
 # Cross-Compile Wine for the guest32 platform to copy higher level DLLs from.
@@ -151,13 +152,14 @@ build.android/wine-guest32/Makefile: build.android/wine-tools/.built wine/config
 	cd $(@D) ; ../../wine/configure --host=i686-w64-mingw32 --with-wine-tools=../wine-tools --without-freetype --disable-tests --with-xml --with-xslt  XML2_CFLAGS="-I$(abspath build.android/i686-w64-mingw32/include/libxml2) -I$(abspath build.android/i686-w64-mingw32/include)" XML2_LIBS="-L$(abspath build.android/i686-w64-mingw32/lib) -lxml2 -liconv"  XSLT_CFLAGS="-I$(abspath build.android/i686-w64-mingw32/include/libxml2) -I$(abspath build.android/i686-w64-mingw32/include)" XSLT_LIBS="-L$(abspath build.android/i686-w64-mingw32/lib) -lxslt -lxml2 -liconv" ac_cv_lib_soname_xslt="libxslt-1.dll"
 
 wine-guest32: build.android/wine-guest32/Makefile
+	+$(MAKE) -C build.android/wine-guest32/libs/port
 	+$(MAKE) -C build.android/wine-guest32 $(patsubst %,dlls/%,$(WINEDLLS))
 
 # Build qemu
 build.android/qemu/Makefile: build.android/aarch64-linux-android/lib/libglib-2.0.so build.android/wine-tools/.built qemu/configure build.android/wine-host/.built
 	@mkdir -p $(@D)
 	+$(MAKE) -C build.android/glib/ install
-	cd $(@D) ; PKG_CONFIG_PATH=$(abspath build.android/aarch64-linux-android/lib/pkgconfig) CC="$(WINE_HOST)/tools/winegcc/winegcc -Wno-macro-redefined -D__ANDROID_API__=22 -I$(NDK_SYSROOT)/usr/include -L$(abspath build.android/aarch64-linux-android/lib) --sysroot=$(WINE_HOST) -b aarch64-linux-android --winebuild $(WINE_HOST)/tools/winebuild/winebuild -I$(WINE_HOST)/include -I$(WINE_SRC)/include --wine-objdir $(WINE_HOST) -DWINE_NOWINSOCK" CXX="" ../../qemu/configure --disable-bzip2 --disable-libusb --disable-sdl --disable-snappy --disable-virtfs --disable-opengl --python=/usr/bin/python2.7 --disable-xen --disable-lzo --disable-qom-cast-debug --disable-vnc --disable-seccomp --disable-strip --disable-hax --disable-gnutls --disable-nettle --disable-replication --disable-tpm --disable-gtk --disable-gcrypt --disable-linux-aio --disable-system --disable-tools --disable-linux-user --disable-guest-agent --enable-windows-user --disable-fdt --disable-capstone --disable-werror ; cd ../.. ; touch $@
+	cd $(@D) ; PKG_CONFIG_PATH=$(abspath build.android/aarch64-linux-android/lib/pkgconfig) CC="$(WINE_HOST)/tools/winegcc/winegcc -Wno-macro-redefined -D__ANDROID_API__=22 -I$(NDK_SYSROOT)/usr/include -L$(abspath build.android/aarch64-linux-android/lib) --sysroot=$(WINE_HOST) -b aarch64-linux-android --winebuild $(WINE_HOST)/tools/winebuild/winebuild -I$(WINE_HOST)/include -I$(WINE_SRC)/include --wine-objdir $(WINE_HOST) -DWINE_NOWINSOCK -U_WIN32 -UWIN64 -UWIN32 -DNOGDI" CXX="" LDFLAGS="--sysroot=$(NDK_SYSROOT)" ../../qemu/configure --disable-bzip2 --disable-libusb --disable-sdl --disable-snappy --disable-virtfs --disable-opengl --python=/usr/bin/python2.7 --disable-xen --disable-lzo --disable-qom-cast-debug --disable-vnc --disable-seccomp --disable-strip --disable-hax --disable-gnutls --disable-nettle --disable-replication --disable-tpm --disable-gtk --disable-gcrypt --disable-linux-aio --disable-system --disable-tools --disable-linux-user --disable-guest-agent --enable-windows-user --disable-fdt --disable-capstone --disable-werror ; cd ../.. ; touch $@
 
 build.android/qemu/x86_64-windows-user/qemu-x86_64.exe.so: build.android/qemu/Makefile
 	+$(MAKE) -C build.android/qemu


### PR DESCRIPTION
I am trying to build hangover for Android. And I got 3 errors.

**1. qemu configure failed**


I tried build hangover for Android using docker first: 
`docker build -f Dockerfile.android -t hob ./`
Then I got error when running configure script for qemu (when making build.android/qemu/Makefile):
```
ERROR: "/root/hangover/build.android/wine-host/tools/winegcc/winegcc -Wno-macro-redefined -D__ANDROID_API__=22 -I/opt/ndk/sysroot/usr/include -L/root/hangover/build.android/aarch64-linux-android/lib --sysroot=/root/hangover/build.android/wine-host -b aarch64-linux-android --winebuild /root/hangover/build.android/wine-host/tools/winebuild/winebuild -I/root/hangover/build.android/wine-host/include -I/root/hangover/wine/include --wine-objdir /root/hangover/build.android/wine-host -DWINE_NOWINSOCK" cannot build an executable (is your linker broken?)
```
Then I tried build without docker. I have android sdk,ndk in my system, and set up a android standalone toolchain, also set ANDRIOD_HOME, NDK_SYSROOT, JAVA_HOME, PATH correctly. I tried build hangover for android without docker:
`make -f Makefile.android`
Then I got exactly the same error as building with docker. It's a configure error, so I come to see build.android/qemu/config.log. Then I found:
```
/home/$USER/dev/android/ndk_toolchain/bin/../lib/gcc/aarch64-linux-android/4.9.x/../../../../aarch64-linux-android/bin/ld: cannot find crtbegin_so.o: No such file or directory
/home/$USER/dev/android/ndk_toolchain/bin/../lib/gcc/aarch64-linux-android/4.9.x/../../../../aarch64-linux-android/bin/ld: cannot find -lm
/home/$USER/dev/android/ndk_toolchain/bin/../lib/gcc/aarch64-linux-android/4.9.x/../../../../aarch64-linux-android/bin/ld: cannot find -lc
/home/$USER/dev/android/ndk_toolchain/bin/../lib/gcc/aarch64-linux-android/4.9.x/../../../../aarch64-linux-android/bin/ld: cannot find -ldl
/home/$USER/dev/android/ndk_toolchain/bin/../lib/gcc/aarch64-linux-android/4.9.x/../../../../aarch64-linux-android/bin/ld: cannot find -lc
/home/$USER/dev/android/ndk_toolchain/bin/../lib/gcc/aarch64-linux-android/4.9.x/../../../../aarch64-linux-android/bin/ld: cannot find -ldl
/home/$USER/dev/android/ndk_toolchain/bin/../lib/gcc/aarch64-linux-android/4.9.x/../../../../aarch64-linux-android/bin/ld: cannot find crtend_so.o: No such file or directory
clang70: error: linker command failed with exit code 1 (use -v to see invocation)
winegcc: aarch64-linux-android-gcc failed
```
It seems that some C libraries are missing. Also, I found these C libraries in `$NDK_SYSROOT/usr/lib`. So I add `LDFLAGS="--sysroot=$(NDK_SYSROOT)"` to the qemu configure line in Makefile.android, and continue building. The error is solved.

**2. 'sys/timeb.h' file not found**

After solve error 1, I continue building with docker. Then I got a new error:
```
$HANGOVER/qemu/slirp/src/slirp.h:19:10: fatal error: 
      'sys/timeb.h' file not found
#include <sys/timeb.h>
```
Just like the first error, this error also happens if I build without docker.

Also, I found that the line which run configure for qemu in normal Makefile(the Makefile for Linux and MacOS)  defines these in CC: `-U_WIN32 -UWIN64 -UWIN32 -DNOGDI`

However, Makefile.android doesn't have these defines. What's more, I found that only if _WIN32 is defined will qemu/slirp/src/slirp.h include sys/timeb.h. So I tried adding these defines to Makefile.android and continue building. This problem is solved.

**3. No rule to make target `../../libs/port/libwine_port.a'**

Continue building, and here comes another error when building wine-guest:
```
make[2]: *** No rule to make target `../../libs/port/libwine_port.a', needed by `dbghelp.dll'.  Stop.
```
libwine_port.a is missing when building dbghelp.dll. If you see the normal Makefile, you will find out that wine-guest/libs/port is built first, here is a piece of normal Makefile:
```
wine-guest: build/wine-guest/Makefile
	+$(MAKE) -C build/wine-guest/libs/port
	+$(MAKE) -C build/wine-guest $(if $(NOTESTS),$(patsubst %,dlls/%,$(WINEDLLS)),)
......
wine-guest32: build/wine-guest32/Makefile
	+$(MAKE) -C build/wine-guest32/libs/port
	+$(MAKE) -C build/wine-guest32 $(if $(NOTESTS),$(patsubst %,dlls/%,$(WINEDLLS)),)
```
Makefile.android doesn't make libs/port first, which leads to the error. So this error can be fixed by making libs/port first when building wine-guest(32).



**Summary**

Error 1 can be fixed by adding `LDFLAGS="--sysroot=$(NDK_SYSROOT)"` to qemu configure line
Error 2 can be fixed by adding `-U_WIN32 -UWIN64 -UWIN32 -DNOGDI` to CC in qemu configure line
Error 3 can be fixed by adding `+$(MAKE) -C build.android/wine-guest/libs/port`

It seems that some errors are caused by making changes in Makefile but forget to make corresponding changes in Makefile.android, such as Error 2 and Error 3

----
I created a pull request that fix these errors in Makefile.android.