### PR TITLE
Makefile: Also set HANGOVER_WINE_CC/HANGOVER_WINE_CXX for Wine tools compilation process.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,9 +118,11 @@ build/x86_64-w64-mingw32/bin/libxslt-1.dll: build/libxslt64/Makefile
 	+$(MAKE) -C build/libxslt64/ install
 
 # Build the wine tools for crosscompilation
+# FIXME: If $HANGOVER_WINE_CC is not set this will define CC to an empty string, which still makes configure
+# happy. Is there a nicer way?
 build/wine-tools/Makefile: wine/configure
 	@mkdir -p $(@D)
-	cd $(@D) ; ../../wine/configure $(ARCHFLAG_TOOLS) --with-freetype --with-gettext --disable-tests --without-alsa --without-capi --without-cms --without-coreaudio --without-cups --without-curses --without-dbus --without-fontconfig --without-gphoto --without-glu --without-gnutls --without-gsm --without-gstreamer --without-hal --without-jpeg --without-krb5 --without-ldap --without-mpg123 --without-netapi --without-openal --without-opencl --without-opengl --without-osmesa --without-oss --without-pcap --without-pulse --without-png --without-sane --without-tiff --without-v4l2 --without-x --without-xcomposite --without-xcursor --without-xinerama --without-xinput --without-xinput2 --without-xml --without-xrandr --without-xrender --without-xshape --without-xshm --without-xslt --without-xxf86vm --without-zlib
+	cd $(@D) ; CC=$(HANGOVER_WINE_CC) CXX=$(HANGOVER_WINE_CXX) ../../wine/configure $(ARCHFLAG_TOOLS) --with-freetype --with-gettext --disable-tests --without-alsa --without-capi --without-cms --without-coreaudio --without-cups --without-curses --without-dbus --without-fontconfig --without-gphoto --without-glu --without-gnutls --without-gsm --without-gstreamer --without-hal --without-jpeg --without-krb5 --without-ldap --without-mpg123 --without-netapi --without-openal --without-opencl --without-opengl --without-osmesa --without-oss --without-pcap --without-pulse --without-png --without-sane --without-tiff --without-v4l2 --without-x --without-xcomposite --without-xcursor --without-xinerama --without-xinput --without-xinput2 --without-xml --without-xrandr --without-xrender --without-xshape --without-xshm --without-xslt --without-xxf86vm --without-zlib
 
 build/wine-tools/.built: build/wine-tools/Makefile
 	+$(MAKE) -C build/wine-tools/libs/port


### PR DESCRIPTION
Tested on Debian bullseye ARM64 with both gcc and clang installed.