### PR TITLE
fixes for d3dretrace + implement some dxgi functions

### DIFF
--- a/dlls/msvcr100/msvcr100.spec
+++ b/dlls/msvcr100/msvcr100.spec
@@ -1486,7 +1486,7 @@
 @ cdecl _waccess_s(wstr long) MSVCRT__waccess_s
 @ cdecl _wasctime(ptr) MSVCRT__wasctime
 @ cdecl _wasctime_s(ptr long ptr) MSVCRT__wasctime_s
-#@ cdecl _wassert(wstr wstr long) MSVCRT__wassert
+@ cdecl _wassert(wstr wstr long) MSVCRT__wassert
 @ cdecl _wchdir(wstr) MSVCRT__wchdir
 @ cdecl _wchmod(wstr long) MSVCRT__wchmod
 @ extern _wcmdln MSVCRT__wcmdln

--- a/dlls/msvcr100/msvcr100.spec
+++ b/dlls/msvcr100/msvcr100.spec
@@ -627,8 +627,8 @@
 @ cdecl -arch=i386 -norelay __libm_sse2_tan() MSVCRT___libm_sse2_tan
 @ cdecl -arch=i386 -norelay __libm_sse2_tanf() MSVCRT___libm_sse2_tanf
 @ extern __mb_cur_max MSVCRT___mb_cur_max
-#@ cdecl __p___argc() MSVCRT___p___argc
-#@ cdecl __p___argv() MSVCRT___p___argv
+@ cdecl __p___argc() MSVCRT___p___argc
+@ cdecl __p___argv() MSVCRT___p___argv
 #@ cdecl __p___initenv()
 @ cdecl __p___mb_cur_max()
 #@ cdecl __p___wargv() MSVCRT___p___wargv

--- a/dlls/msvcr100/msvcr100.spec
+++ b/dlls/msvcr100/msvcr100.spec
@@ -1280,7 +1280,7 @@
 @ cdecl _set_controlfp(long long)
 @ cdecl _set_doserrno(long) MSVCRT__set_doserrno
 @ cdecl _set_errno(long)
-#@ cdecl _set_error_mode(long)
+@ cdecl _set_error_mode(long) MSVCRT__set_error_mode
 @ cdecl _set_fmode(long) MSVCRT__set_fmode
 @ cdecl _set_invalid_parameter_handler(ptr) MSVCRT__set_invalid_parameter_handler
 @ stub _set_malloc_crt_max_wait

--- a/dlls/msvcr80/msvcr80.spec
+++ b/dlls/msvcr80/msvcr80.spec
@@ -959,7 +959,7 @@
 @ cdecl _set_controlfp(long long)
 @ cdecl _set_doserrno(long) MSVCRT__set_doserrno
 @ cdecl _set_errno(long)
-#@ cdecl _set_error_mode(long)
+@ cdecl _set_error_mode(long) MSVCRT__set_error_mode
 @ cdecl _set_fmode(long) MSVCRT__set_fmode
 @ cdecl _set_invalid_parameter_handler(ptr) MSVCRT__set_invalid_parameter_handler
 @ stub _set_malloc_crt_max_wait

--- a/dlls/msvcr80/msvcr80.spec
+++ b/dlls/msvcr80/msvcr80.spec
@@ -270,8 +270,8 @@
 @ cdecl -arch=i386 -norelay __libm_sse2_tan() MSVCRT___libm_sse2_tan
 @ cdecl -arch=i386 -norelay __libm_sse2_tanf() MSVCRT___libm_sse2_tanf
 @ extern __mb_cur_max MSVCRT___mb_cur_max
-#@ cdecl __p___argc() MSVCRT___p___argc
-#@ cdecl __p___argv() MSVCRT___p___argv
+@ cdecl __p___argc() MSVCRT___p___argc
+@ cdecl __p___argv() MSVCRT___p___argv
 #@ cdecl __p___initenv()
 @ cdecl __p___mb_cur_max()
 #@ cdecl __p___wargv() MSVCRT___p___wargv

--- a/dlls/msvcr80/msvcr80.spec
+++ b/dlls/msvcr80/msvcr80.spec
@@ -1165,7 +1165,7 @@
 @ cdecl _waccess_s(wstr long) MSVCRT__waccess_s
 @ cdecl _wasctime(ptr) MSVCRT__wasctime
 @ cdecl _wasctime_s(ptr long ptr) MSVCRT__wasctime_s
-#@ cdecl _wassert(wstr wstr long) MSVCRT__wassert
+@ cdecl _wassert(wstr wstr long) MSVCRT__wassert
 @ cdecl _wchdir(wstr) MSVCRT__wchdir
 @ cdecl _wchmod(wstr long) MSVCRT__wchmod
 @ extern _wcmdln MSVCRT__wcmdln

--- a/dlls/msvcrt/exit.c
+++ b/dlls/msvcrt/exit.c
@@ -328,6 +328,38 @@ void qemu__assert(struct qemu_syscall *call)
 
 #endif
 
+struct qemu__wassert
+{
+    struct qemu_syscall super;
+    uint64_t str;
+    uint64_t file;
+    uint64_t line;
+};
+
+#ifdef QEMU_DLL_GUEST
+
+WINBASEAPI void CDECL MSVCRT__wassert(const wchar_t* str, const wchar_t* file, unsigned int line)
+{
+    struct qemu__wassert call;
+    call.super.id = QEMU_SYSCALL_ID(CALL__WASSERT);
+    call.str = (ULONG_PTR)str;
+    call.file = (ULONG_PTR)file;
+    call.line = line;
+
+    qemu_syscall(&call.super);
+}
+
+#else
+
+void qemu__wassert(struct qemu_syscall *call)
+{
+    struct qemu__wassert *c = (struct qemu_w_assert *)call;
+    WINE_FIXME("Unverified!\n");
+    p__wassert(QEMU_G2H(c->str), QEMU_G2H(c->file), c->line);
+}
+
+#endif
+
 struct qemu__set_error_mode
 {
     struct qemu_syscall super;

--- a/dlls/msvcrt/exit.c
+++ b/dlls/msvcrt/exit.c
@@ -327,3 +327,33 @@ void qemu__assert(struct qemu_syscall *call)
 }
 
 #endif
+
+struct qemu__set_error_mode
+{
+    struct qemu_syscall super;
+    int32_t mode;
+};
+
+#ifdef QEMU_DLL_GUEST
+
+WINBASEAPI int CDECL MSVCRT__set_error_mode(int mode)
+{
+    struct qemu__set_error_mode call;
+    call.super.id = QEMU_SYSCALL_ID(CALL__SET_ERROR_MODE);
+    call.mode = mode;
+
+    qemu_syscall(&call.super);
+
+    return call.super.iret;
+}
+
+#else
+
+void qemu__set_error_mode(struct qemu_syscall *call)
+{
+    struct qemu__set_error_mode *c = (struct qemu__set_error_mode *)call;
+    WINE_TRACE("\n");
+    c->super.iret = p__set_error_mode(c->mode);
+}
+
+#endif

--- a/dlls/msvcrt/file.c
+++ b/dlls/msvcrt/file.c
@@ -4566,7 +4566,6 @@ int CDECL MSVCRT_fputc(int c, FILE* file)
 void qemu_fputc(struct qemu_syscall *call)
 {
     struct qemu_fputc *c = (struct qemu_fputc *)(ULONG_PTR)call;
-    WINE_FIXME("Unverified!\n");
     c->super.iret = p_fputc(c->c, FILE_g2h(c->file));
 }
 

--- a/dlls/msvcrt/main.c
+++ b/dlls/msvcrt/main.c
@@ -714,6 +714,7 @@ static void qemu_init_dll(struct qemu_syscall *call)
         p__set_controlfp = (void *)GetProcAddress(msvcrt, "_set_controlfp");
         p__set_doserrno = (void *)GetProcAddress(msvcrt, "_set_doserrno");
         p__set_errno = (void *)GetProcAddress(msvcrt, "_set_errno");
+        p__set_error_mode = (void *)GetProcAddress(msvcrt, "_set_error_mode");
         p__set_FMA3_enable = (void *)GetProcAddress(msvcrt, "_set_FMA3_enable");
         p__set_fmode = (void *)GetProcAddress(msvcrt, "_set_fmode");
         p__set_invalid_parameter_handler = (void *)GetProcAddress(msvcrt, "_set_invalid_parameter_handler");
@@ -1807,6 +1808,7 @@ static const syscall_handler dll_functions[] =
     qemu__set_controlfp,
     qemu__set_doserrno,
     qemu__set_errno,
+    qemu__set_error_mode,
     qemu__set_FMA3_enable,
     qemu__set_fmode,
     qemu__set_invalid_parameter_handler,

--- a/dlls/msvcrt/main.c
+++ b/dlls/msvcrt/main.c
@@ -339,6 +339,7 @@ static void qemu_init_dll(struct qemu_syscall *call)
         p__aligned_realloc = (void *)GetProcAddress(msvcrt, "_aligned_realloc");
         p__amsg_exit = (void *)GetProcAddress(msvcrt, "_amsg_exit");
         p__assert = (void *)GetProcAddress(msvcrt, "_assert");
+        p__wassert = (void *)GetProcAddress(msvcrt, "_wassert");
         p__atodbl = (void *)GetProcAddress(msvcrt, "_atodbl");
         p__atodbl_l = (void *)GetProcAddress(msvcrt, "_atodbl_l");
         p__atof_l = (void *)GetProcAddress(msvcrt, "_atof_l");
@@ -1915,6 +1916,7 @@ static const syscall_handler dll_functions[] =
     qemu__waccess_s,
     qemu__wasctime,
     qemu__wasctime_s,
+    qemu__wassert,
     qemu__wchdir,
     qemu__wchmod,
     qemu__wcreat,

--- a/dlls/msvcrt/msvcrt.spec
+++ b/dlls/msvcrt/msvcrt.spec
@@ -899,7 +899,7 @@
 @ cdecl _set_controlfp(long long)
 @ cdecl _set_doserrno(long) MSVCRT__set_doserrno
 @ cdecl _set_errno(long)
-# @ cdecl _set_error_mode(long)
+@ cdecl _set_error_mode(long) MSVCRT__set_error_mode
 # stub _set_fileinfo(long)
 @ cdecl _set_fmode(long) MSVCRT__set_fmode
 # @ cdecl _set_output_format(long) MSVCRT__set_output_format

--- a/dlls/msvcrt/msvcrt.spec
+++ b/dlls/msvcrt/msvcrt.spec
@@ -248,8 +248,8 @@
 @ cdecl -arch=i386 -norelay __libm_sse2_tan() MSVCRT___libm_sse2_tan
 @ cdecl -arch=i386 -norelay __libm_sse2_tanf() MSVCRT___libm_sse2_tanf
 @ extern __mb_cur_max MSVCRT___mb_cur_max
-# @ cdecl __p___argc() MSVCRT___p___argc
-# @ cdecl __p___argv() MSVCRT___p___argv
+@ cdecl __p___argc() MSVCRT___p___argc
+@ cdecl __p___argv() MSVCRT___p___argv
 @ cdecl __p___initenv()
 @ cdecl __p___mb_cur_max()
 # @ cdecl __p___wargv() MSVCRT___p___wargv

--- a/dlls/msvcrt/msvcrt.spec
+++ b/dlls/msvcrt/msvcrt.spec
@@ -1095,7 +1095,7 @@
 @ cdecl _waccess_s(wstr long) MSVCRT__waccess_s
 @ cdecl _wasctime(ptr) MSVCRT__wasctime
 @ cdecl _wasctime_s(ptr long ptr) MSVCRT__wasctime_s
-# @ cdecl _wassert(wstr wstr long) MSVCRT__wassert
+@ cdecl _wassert(wstr wstr long) MSVCRT__wassert
 @ cdecl _wchdir(wstr) MSVCRT__wchdir
 @ cdecl _wchmod(wstr long) MSVCRT__wchmod
 @ extern _wcmdln MSVCRT__wcmdln

--- a/dlls/msvcrt/qemu_msvcrt.h
+++ b/dlls/msvcrt/qemu_msvcrt.h
@@ -583,6 +583,7 @@ enum msvcrt_calls
     CALL__WACCESS_S,
     CALL__WASCTIME,
     CALL__WASCTIME_S,
+    CALL__WASSERT,
     CALL__WCHDIR,
     CALL__WCHMOD,
     CALL__WCREAT,
@@ -1797,6 +1798,7 @@ void qemu__waccess(struct qemu_syscall *c);
 void qemu__waccess_s(struct qemu_syscall *c);
 void qemu__wasctime(struct qemu_syscall *call);
 void qemu__wasctime_s(struct qemu_syscall *call);
+void qemu__wassert(struct qemu_syscall *call);
 void qemu__wchdir(struct qemu_syscall *call);
 void qemu__wchmod(struct qemu_syscall *c);
 void qemu__wcreat(struct qemu_syscall *c);
@@ -3272,6 +3274,7 @@ double (* CDECL p_strtod_l)(const char *str, char **end, MSVCRT__locale_t locale
 float (* CDECL p__strtof_l)(const char *str, char **end, MSVCRT__locale_t locale);
 float (* CDECL p_strtof)(const char *str, char **end);
 void (* CDECL p__assert)(const char* str, const char* file, unsigned int line);
+void (* CDECL p__wassert)(const wchar_t* str, const wchar_t* file, unsigned int line);
 double (* CDECL p__atof_l)(const char *str, MSVCRT__locale_t locale);
 int (* CDECL p__atoflt_l)(FLOAT *value, char *str, MSVCRT__locale_t locale);
 int (* CDECL p__atoflt)(FLOAT *value, char *str);

--- a/dlls/msvcrt/qemu_msvcrt.h
+++ b/dlls/msvcrt/qemu_msvcrt.h
@@ -476,6 +476,7 @@ enum msvcrt_calls
     CALL__SET_CONTROLFP,
     CALL__SET_DOSERRNO,
     CALL__SET_ERRNO,
+    CALL__SET_ERROR_MODE,
     CALL__SET_FMA3_ENABLE,
     CALL__SET_FMODE,
     CALL__SET_INVALID_PARAMETER_HANDLER,
@@ -1692,6 +1693,7 @@ void qemu__searchenv_s(struct qemu_syscall *call);
 void qemu__set_controlfp(struct qemu_syscall *call);
 void qemu__set_doserrno(struct qemu_syscall *call);
 void qemu__set_errno(struct qemu_syscall *call);
+void qemu__set_error_mode(struct qemu_syscall *call);
 void qemu__set_FMA3_enable(struct qemu_syscall *call);
 void qemu__set_fmode(struct qemu_syscall *call);
 void qemu__set_invalid_parameter_handler(struct qemu_syscall *call);
@@ -2897,6 +2899,7 @@ ULONG* (* CDECL p___doserrno)(void);
 int (* CDECL p__get_errno)(int *pValue);
 int (* CDECL p__get_doserrno)(int *pValue);
 int (* CDECL p__set_errno)(int value);
+int (* CDECL p__set_error_mode)(int mode);
 int (* CDECL p__set_doserrno)(int value);
 char* (* CDECL p_strerror)(int err);
 int (* CDECL p_strerror_s)(char *buffer, size_t numberOfElements, int errnum);

--- a/dlls/msvcrt/qemu_msvcrt.h
+++ b/dlls/msvcrt/qemu_msvcrt.h
@@ -3408,7 +3408,7 @@ static inline uint64_t FILE_h2g(MSVCRT_FILE *host)
         size_t offset;
         offset = (host - host_iob);
         if (offset <= guest_iob_size)
-            return QEMU_H2G(guest_iob + offset * guest_iob_size);
+            return QEMU_H2G(guest_iob + offset * guest_FILE_size);
     }
     return QEMU_H2G(host);
 #endif

--- a/dlls/ucrtbase/ucrtbase.spec
+++ b/dlls/ucrtbase/ucrtbase.spec
@@ -1495,7 +1495,7 @@
 @ cdecl _waccess_s(wstr long) MSVCRT__waccess_s
 @ cdecl _wasctime(ptr) MSVCRT__wasctime
 @ cdecl _wasctime_s(ptr long ptr) MSVCRT__wasctime_s
-#@ cdecl _wassert(wstr wstr long) MSVCRT__wassert
+@ cdecl _wassert(wstr wstr long) MSVCRT__wassert
 @ cdecl _wchdir(wstr) MSVCRT__wchdir
 @ cdecl _wchmod(wstr long) MSVCRT__wchmod
 @ extern _wcmdln MSVCRT__wcmdln

--- a/dlls/ucrtbase/ucrtbase.spec
+++ b/dlls/ucrtbase/ucrtbase.spec
@@ -1289,7 +1289,7 @@
 @ cdecl _set_controlfp(long long)
 @ cdecl _set_doserrno(long) MSVCRT__set_doserrno
 @ cdecl _set_errno(long)
-#@ cdecl _set_error_mode(long)
+@ cdecl _set_error_mode(long) MSVCRT__set_error_mode
 @ cdecl _set_fmode(long) MSVCRT__set_fmode
 @ cdecl _set_invalid_parameter_handler(ptr) MSVCRT__set_invalid_parameter_handler
 @ stub _set_malloc_crt_max_wait


### PR DESCRIPTION
For the last few weeks I've been working on getting a trace of a Unity DX11 game (Overcooked 2) to be replayed using hangover. This is a collection of fixes and API implementations that's upstreamable so far. This should be enough to get the trace to replay when the host driver/wine DX implementation supports DX11.