### PR TITLE
Fix national language support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,7 @@ build/wine-guest/Makefile: build/wine-host/.built wine/configure build/x86_64-w6
 
 build/wine-guest/.built: build/wine-guest/Makefile
 	+$(MAKE) -C build/wine-guest/libs/port
+	+$(MAKE) -C build/wine-guest/dlls/kernel32 locale_rc.res
 	+$(MAKE) -C build/wine-guest
 	@touch build/wine-guest/.built
 
@@ -169,6 +170,7 @@ build/wine-guest32/Makefile: build/wine-host/.built wine/configure build/i686-w6
 
 build/wine-guest32/.built: build/wine-guest32/Makefile
 	+$(MAKE) -C build/wine-guest32/libs/port
+	+$(MAKE) -C build/wine-guest32/dlls/kernel32 locale_rc.res
 	+$(MAKE) -C build/wine-guest32
 	@touch build/wine-guest32/.built
 

--- a/dlls/kernel32/Makefile
+++ b/dlls/kernel32/Makefile
@@ -9,7 +9,7 @@ VPATH=$(SRCDIR)
 all: kernel32.dll qemu_kernel32.dll.so
 
 kernel32.dll: actctx_g.o atom_g.o change_g.o comm_g.o computername_g.o console_g.o cpu_g.o debugger_g.o environ_g.o except_g.o fiber_g.o file_g.o format_msg_g.o heap_g.o kernel32.spec lcformat_g.o locale_g.o lzexpand_g.o main_g.o module_g.o path_g.o powermgnt_g.o process_g.o profile_g.o resource_g.o special_g.o string_g.o sync_g.o tape_g.o thread_g.o time_g.o toolhelp_g.o version_g.o virtual_g.o volume_g.o wer_g.o my_winternl.h
-	$(WINEGCC) --wine-objdir $(DESTDIR)/build/$(WINE_DIR) -shared -b $(GUEST_CC) $(SRCDIR)/kernel32.spec *_g.o -lwinecrt0 -o kernel32.dll -lntdll -lkernelbase -lgcc -nodefaultlibs -nostdlib -Wl,--image-base,0x20000000
+	$(WINEGCC) --wine-objdir $(DESTDIR)/build/$(WINE_DIR) -shared -b $(GUEST_CC) $(SRCDIR)/kernel32.spec *_g.o $(DESTDIR)/build/$(WINE_DIR)/dlls/kernel32/locale_rc.res -lwinecrt0 -o kernel32.dll -lntdll -lkernelbase -lgcc -nodefaultlibs -nostdlib -Wl,--image-base,0x20000000
 
 qemu_kernel32.dll.so: actctx_h.o atom_h.o change_h.o comm_h.o computername_h.o console_h.o cpu_h.o debugger_h.o environ_h.o except_h.o fiber_h.o file_h.o format_msg_h.o heap_h.o lcformat_h.o locale_h.o lzexpand_h.o main_h.o module_h.o path_h.o powermgnt_h.o process_h.o profile_h.o qemu_kernel32.spec resource_h.o special_h.o string_h.o sync_h.o tape_h.o thread_h.o time_h.o toolhelp_h.o version_h.o virtual_h.o volume_h.o wer_h.o
 	$(WINEGCC) --wine-objdir $(DESTDIR)/build/wine-host -shared $(HOST_CC) $(SRCDIR)/qemu_kernel32.spec *_h.o -lwine ../../libffi/installed/lib/libffi.a -o qemu_kernel32.dll.so

--- a/dlls/ntdll/rtlstr.c
+++ b/dlls/ntdll/rtlstr.c
@@ -1493,8 +1493,16 @@ WINBASEAPI NTSTATUS WINAPI RtlGUIDFromString(PUNICODE_STRING str, GUID* guid)
 void qemu_RtlGUIDFromString(struct qemu_syscall *call)
 {
     struct qemu_RtlGUIDFromString *c = (struct qemu_RtlGUIDFromString *)call;
-    WINE_FIXME("Unverified!\n");
-    c->super.iret = RtlGUIDFromString(QEMU_G2H(c->str), QEMU_G2H(c->guid));
+    UNICODE_STRING str_stack, *str = &str_stack;
+
+    WINE_TRACE("\n");
+#if GUEST_BIT == HOST_BIT
+    str = QEMU_G2H(c->str);
+#else
+    UNICODE_STRING_g2h(str, QEMU_G2H(c->str));
+#endif
+
+    c->super.iret = RtlGUIDFromString(str, QEMU_G2H(c->guid));
 }
 
 #endif


### PR DESCRIPTION
In normal wine, kernel32.dll should contain resources for NLS. But we didn't have them in Hangover's wrapper kernel32.dll. So the first commit add the NLS resources to wrapper kernel32.dll.

The second commit fixes RtlGUIDFromString, which is called during NLS initialization.