### PR TITLE
Fix build of the hangover

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ build/wine-host/Makefile: wine/configure build/wine-tools/.built
 	cd build/wine-host ; CC=$(HANGOVER_WINE_CC) CXX=$(HANGOVER_WINE_CXX) ../../wine/configure --with-wine-tools=../wine-tools --without-mingw $(ARCHFLAG_HOST) $(TESTS) $(CROSS_TRIPLE_H)
 
 wine-host build/wine-host/.built: build/wine-host/Makefile
+	+$(MAKE) -C build/wine-host dlls/wsock32/libwsock32.def # workaround for dlls/wsock32/Makefile
 	+$(MAKE) -C build/wine-host
 	@touch build/wine-host/.built
 


### PR DESCRIPTION
Build manually libwsock32.def because `make -C build/wine-host` no longer builds libwsock32.def.

Fix https://github.com/AndreRH/hangover/runs/1930721873.
```
2021-02-19T00:07:13.4667017Z ../../../build/wine-tools/tools/winegcc/winegcc --winebuild ../../../build/wine-tools/tools/winebuild/winebuild -I../../../build/wine-host/include -I../../../wine/include --wine-objdir ../../../build/wine-host -shared -Wno-pragma-pack  ../../../dlls/wsock32/qemu_wsock32.spec *_h.o -o qemu_wsock32.dll.so -lwsock32
2021-02-19T00:07:13.5686030Z [91m/usr/bin/ld: cannot find -lwsock32
```

A wild guess: Previously (e.g. hangover-0.5.15), host wine was building all *.def files at the beginning of the build (cf. `build/wine-host/Makefile:__builddeps__`). Currently, host wine no longer builds unnecessary \*.def files (possibly by https://github.com/wine-mirror/wine/commit/1dd3051cca5cafe90ce44460731df61abb680b3b). Thus, Build will fail because of \*.def files that host wine does not depend on and the hangover depends on.